### PR TITLE
Gracefully handle non-JSON Instagram responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Unfollow-Unfollowers
-Use this tool to find out who amongst your following no longer follows you
+
+A static web page that checks which accounts a public Instagram profile follows that do not follow back. It can be hosted on [GitHub Pages](https://pages.github.com/) for anyone to use online.
+
+## Usage
+
+1. Open the site (for local testing run `python -m http.server` and visit `http://localhost:8000`).
+2. Enter a public Instagram profile link or username.
+3. The page lists accounts that the profile follows but who don't follow back.
+
+The scraper relies on public Instagram endpoints and may stop working if Instagram changes their interface or rate limits requests. If the page shows an error message, the profile may be private or Instagram may have blocked the request.
+
+## Deploying to GitHub Pages
+
+1. Commit your changes to the `main` branch.
+2. In the repository settings, enable GitHub Pages and select `main` as the source.
+3. Your site will be available at `https://<username>.github.io/Unfollow-Unfollowers/`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Instagram Unfollowers</title>
+    <style>
+      body { font-family: Arial, sans-serif; text-align: center; margin-top: 40px; }
+      input[type=text] { width: 60%; padding: 10px; }
+      button { padding: 10px 20px; margin-left: 10px; }
+      ul { list-style-type: none; padding: 0; }
+    </style>
+    <script src="script.js" defer></script>
+  </head>
+  <body>
+    <h1>Instagram Unfollowers</h1>
+    <form id="check-form">
+      <input type="text" id="profile" placeholder="Public profile link or username" required>
+      <button type="submit">Check</button>
+    </form>
+    <p>Profile must be public and accessible without login.</p>
+    <ul id="results"></ul>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,52 @@
+async function fetchJSON(path) {
+  const res = await fetch(`https://r.jina.ai/https://www.instagram.com/api/v1/${path}`);
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`request failed with ${res.status}: ${text}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(text.slice(0, 100));
+  }
+}
+
+async function collectUsers(id, type) {
+  let users = [];
+  let next = '';
+  do {
+    const data = await fetchJSON(`friendships/${id}/${type}/?count=1000&max_id=${next}`);
+    users = users.concat(data.users);
+    next = data.next_max_id || '';
+  } while (next);
+  return users;
+}
+
+async function getUnfollowers(username) {
+  const info = await fetchJSON(`users/web_profile_info/?username=${username}`);
+  const id = info.data.user.id;
+  const [followers, following] = await Promise.all([
+    collectUsers(id, 'followers'),
+    collectUsers(id, 'following')
+  ]);
+  const followerSet = new Set(followers.map(u => u.username));
+  return following.filter(u => !followerSet.has(u.username)).map(u => u.username);
+}
+
+document.getElementById('check-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const raw = document.getElementById('profile').value.trim();
+  const username = raw.split('/').filter(Boolean).pop();
+  const list = document.getElementById('results');
+  list.innerHTML = '<li>Loading...</li>';
+  try {
+    const unfollowers = await getUnfollowers(username);
+    if (!unfollowers.length) {
+      list.innerHTML = '<li>No unfollowers found</li>';
+    } else {
+      list.innerHTML = unfollowers.map(u => `<li>${u}</li>`).join('');
+    }
+  } catch (err) {
+    list.innerHTML = `<li>Error: ${err.message}</li>`;
+  }
+});


### PR DESCRIPTION
## Summary
- parse Instagram responses as text and surface clearer errors when JSON parsing fails
- document potential failure reasons when scraping public profiles

## Testing
- `node --check script.js`
- `python -m http.server`


------
https://chatgpt.com/codex/tasks/task_e_68aed8a7c2e08332ab2231f1131342da